### PR TITLE
fix : file_path로 실행 할 경우 리턴값 수정

### DIFF
--- a/src/utils/find_execute_file_path.c
+++ b/src/utils/find_execute_file_path.c
@@ -6,7 +6,7 @@
 /*   By: sungjpar <sungjpar@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/21 17:07:36 by mingylee          #+#    #+#             */
-/*   Updated: 2022/08/22 21:30:11 by sungjpar         ###   ########.fr       */
+/*   Updated: 2022/08/23 16:16:50 by mingylee         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,8 @@ char	*find_execute_file_path(char *command_name)
 	char	*excute_file;
 
 	path_index = 0;
+	if (check_permission(command_name))
+		return (ft_strdup(command_name));
 	command = ft_strjoin("/", command_name);
 	path = get_paths();
 	while (path[path_index])


### PR DESCRIPTION
cat 으로 명령어가 들어오는것이 아니라 /bin/cat 으로 직접 실행 파일을 지정 했을 경우를 수정했습니다